### PR TITLE
✨ Add scripts to clean GCS CSVs and load them to BigQuery

### DIFF
--- a/scripts/clean_gcs_csv_headers.py
+++ b/scripts/clean_gcs_csv_headers.py
@@ -1,0 +1,54 @@
+from google.cloud import storage
+import pandas as pd
+import re
+import os
+
+# === Config ===
+project_id = "carbide-bonsai-466217-v2"
+bucket_name = "league-scouting-platform_bronze"
+local_output_folder = "data/bronze_scrapping"
+os.makedirs(local_output_folder, exist_ok=True)
+
+# === Connexion GCS ===
+print("🚀 Connexion à GCS...")
+storage_client = storage.Client(project=project_id)
+bucket = storage_client.bucket(bucket_name)
+
+# === Fonction de nettoyage des noms de colonnes ===
+def clean_column_name(col):
+    col = col.strip()
+    if re.match(r"^\d+(\.\d+)?$", col):  # nom numérique (ex: "0.625")
+        col = f"col_{col.replace('.', '_')}"
+    col = re.sub(r"\s+", "_", col)
+    col = re.sub(r"[^a-zA-Z0-9_]", "", col)
+    return col.lower()
+
+# === Traitement ===
+print("📦 Recherche des fichiers CSV à la racine de GCS...")
+blobs = bucket.list_blobs(prefix="")
+
+for blob in blobs:
+    if not blob.name.endswith(".csv") or "/" in blob.name.strip("/"):
+        continue
+
+    print(f"\n📥 Téléchargement de `{blob.name}`...")
+    local_path = os.path.join(local_output_folder, os.path.basename(blob.name))
+    blob.download_to_filename(local_path)
+    print(f"✅ Fichier téléchargé : {local_path}")
+
+    try:
+        # Lecture et nettoyage des colonnes
+        df = pd.read_csv(local_path)
+        original_cols = list(df.columns)
+        cleaned_cols = [clean_column_name(c) for c in original_cols]
+
+        if original_cols != cleaned_cols:
+            print("🧼 Colonnes modifiées pour compatibilité BQ.")
+            df.columns = cleaned_cols
+            df.to_csv(local_path, index=False)
+            print(f"✅ Colonnes nettoyées et fichier réécrit : {local_path}")
+        else:
+            print("✅ Colonnes déjà valides. Pas de nettoyage nécessaire.")
+
+    except Exception as e:
+        print(f"❌ Erreur pendant le traitement de {blob.name} : {e}")

--- a/scripts/load_cleaned_csvs_to_bq.py
+++ b/scripts/load_cleaned_csvs_to_bq.py
@@ -1,0 +1,41 @@
+from google.cloud import bigquery
+import os
+import re
+
+# === Config ===
+project_id = "carbide-bonsai-466217-v2"
+dataset_id = "bronze"
+local_folder = "data/bronze_scrapping"
+
+# === Initialisation client BigQuery ===
+print("🚀 Connexion à BigQuery...")
+bq_client = bigquery.Client(project=project_id)
+
+# === Parcours des fichiers dans le dossier ===
+print(f"📁 Lecture des fichiers dans `{local_folder}`...")
+for filename in os.listdir(local_folder):
+    if not filename.endswith(".csv"):
+        continue
+
+    file_path = os.path.join(local_folder, filename)
+    table_name = re.sub(r"[^a-zA-Z0-9_]", "_", filename.replace(".csv", "")).lower()
+    table_id = f"{project_id}.{dataset_id}.{table_name}"
+
+    print(f"\n🔄 Chargement de `{file_path}` dans `{table_id}`...")
+
+    job_config = bigquery.LoadJobConfig(
+        source_format=bigquery.SourceFormat.CSV,
+        skip_leading_rows=1,
+        autodetect=True,
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+    )
+
+    try:
+        with open(file_path, "rb") as file:
+            load_job = bq_client.load_table_from_file(
+                file, table_id, job_config=job_config
+            )
+            load_job.result()
+        print(f"✅ Terminé : {table_id}")
+    except Exception as e:
+        print(f"❌ Erreur pour {table_id} : {e}")


### PR DESCRIPTION
Objectif
Automatiser l’ingestion des fichiers CSV (stats NBA) dans BigQuery, en assurant la compatibilité des noms de colonnes avec les contraintes de BQ.

🧱 Ce qui a été fait :
Nettoyage des entêtes CSV invalides (ex. "0.625" → col_0_625) pour éviter les erreurs Field name not supported dans BigQuery

Création d’un script :

scripts/sync_cleaned_gcs_csvs.py → télécharge tous les fichiers .csv à la racine de GCS, nettoie les en-têtes et les sauvegarde localement dans data/bronze_scrapping/

Création d’un deuxième script :

scripts/load_cleaned_csvs_to_bq.py → charge les fichiers nettoyés vers le dataset BigQuery bronze, avec autodétection du schéma et WRITE_TRUNCATE

📁 Données traitées :
Fichiers concernés (téléchargés depuis league-scouting-platform_bronze et nettoyés) :

NBA Contracts Complete.csv

Player_Stats_Playoff.csv

Players_stats_Regular.csv

Team Stats Playoff.csv

Team Stats Regular.csv

